### PR TITLE
fix(ci): resolve shell interpretation error in create-release-pr work…

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -158,14 +158,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.release_info.outputs.version }}"
-          DESCRIPTION="${{ steps.pr_description.outputs.description }}"
 
-          # Create the PR
+          # Save PR description to file to avoid shell interpretation issues
+          cat << 'PR_BODY_EOF' > pr_description.txt
+          ${{ steps.pr_description.outputs.description }}
+          PR_BODY_EOF
+
+          # Create the PR using --body-file to avoid shell interpretation issues
           PR_URL=$(gh pr create \
             --base main \
             --head preview \
             --title "🚀 Release v$VERSION" \
-            --body "$DESCRIPTION" \
+            --body-file pr_description.txt \
             --label "release,automated" \
             --assignee "${{ github.repository_owner }}")
 


### PR DESCRIPTION
…flow

* Replace direct variable usage in --body parameter with --body-file approach
* Write PR description to temporary file using here-document with quoted delimiter
* Prevents shell from interpreting special characters in multi-line PR descriptions
* Eliminates 'command not found' errors when description contains words like 'preview' and 'main'

This fixes the workflow failure where GitHub CLI was interpreting markdown content as shell commands instead of treating it as PR body text.