### PR TITLE
Fix release notes processor tests

### DIFF
--- a/.github/actions/openai-chat/entrypoint.sh
+++ b/.github/actions/openai-chat/entrypoint.sh
@@ -116,6 +116,8 @@ if [[ ${OPENAI_TEST_MODE:-false} == "true" ]]; then
       MOCK_FILE="$MOCK_DIR/pr-enhancement.json"
     elif [[ $OUTPUT =~ pr-description ]]; then
       MOCK_FILE="$MOCK_DIR/pr-description.json"
+    elif [[ $OUTPUT =~ release-notes ]]; then
+      MOCK_FILE="$MOCK_DIR/release-notes.json"
     else
       MOCK_FILE="$MOCK_DIR/generic.json"
     fi
@@ -127,6 +129,8 @@ if [[ ${OPENAI_TEST_MODE:-false} == "true" ]]; then
       MOCK_FILE="$MOCK_DIR/pr-enhancement.json"
     elif [[ $TEMPLATE =~ pr-description ]]; then
       MOCK_FILE="$MOCK_DIR/pr-description.json"
+    elif [[ $TEMPLATE =~ release-notes ]]; then
+      MOCK_FILE="$MOCK_DIR/release-notes.json"
     else
       MOCK_FILE="$MOCK_DIR/generic.json"
     fi

--- a/.github/actions/openai-chat/processors/generic.sh
+++ b/.github/actions/openai-chat/processors/generic.sh
@@ -54,10 +54,10 @@ main() {
   # Check if content is valid JSON
   if echo "$content" | jq . >/dev/null 2>&1; then
     # JSON content - do structured processing
-    process_json_content "$processed_template" "$content"
+    process_json_content "$processed_template" "$content" "$vars"
   else
     # Non-JSON content - do simple replacement
-    process_plain_content "$processed_template" "$content"
+    process_plain_content "$processed_template" "$content" "$vars"
   fi
 }
 
@@ -65,6 +65,7 @@ main() {
 process_json_content() {
   local template="$1"
   local content="$2"
+  local vars="$3"
   local result="$template"
   
   # First, collect all {{field}} patterns from template and replace with values or empty strings
@@ -90,7 +91,10 @@ process_json_content() {
   
   # Replace {{content}} with the raw JSON
   result="${result//\{\{content\}\}/$content}"
-  
+
+  # Re-apply variables so they can override JSON fields
+  result=$(process_template_vars "$result" "$vars")
+
   printf '%s' "$result"
 }
 
@@ -98,10 +102,14 @@ process_json_content() {
 process_plain_content() {
   local template="$1"
   local content="$2"
-  
+  local vars="$3"
+
   # Just replace {{content}} with the raw content
   local result="${template//\{\{content\}\}/$content}"
-  
+
+  # Re-apply variables for consistency with JSON mode
+  result=$(process_template_vars "$result" "$vars")
+
   printf '%s' "$result"
 }
 

--- a/.github/tests/fixtures/release-notes.json
+++ b/.github/tests/fixtures/release-notes.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.1.0",
+  "summary": "This release focuses on infrastructure improvements and bug fixes—there are no user-facing or API changes.",
+  "primary_section": {
+    "title": "Infrastructure Improvements", 
+    "emoji": "🛠️",
+    "features": [
+      "**Enhanced CI pipeline** reduces build times by 25%",
+      "**Improved error handling** provides clearer debugging information",
+      "**Updated dependencies** ensure latest security patches"
+    ]
+  },
+  "secondary_sections": [
+    {
+      "title": "Bug Fixes",
+      "emoji": "🐛", 
+      "features": [
+        "**Memory leak resolved** in long-running processes",
+        "**Race condition fixed** in concurrent requests"
+      ]
+    }
+  ],
+  "commit_analysis": {
+    "total_commits": 5,
+    "feat_count": 2,
+    "fix_count": 2,
+    "chore_count": 1,
+    "ci_count": 3,
+    "docs_count": 0,
+    "breaking_changes_detected": false
+  },
+  "breaking_changes": "",
+  "footer_links": {
+    "npm": "https://www.npmjs.com/package/setlistfm-ts",
+    "changelog": "https://github.com/tkozzer/setlistfm-ts/blob/main/CHANGELOG.md",
+    "issues": "https://github.com/tkozzer/setlistfm-ts/issues"
+  }
+}


### PR DESCRIPTION
## Summary
- add missing release notes fixture for OpenAI mocks
- enable OPENAI_TEST_MODE in release notes processor tests
- improve OpenAI fallback/success/failure tests
- update generic processor to allow variable override
- support release-notes.json in openai-chat entrypoint

## Testing
- `./.github/tests/processors/test-release-notes-processor.sh`
- `./.github/tests/run-all-tests.sh`
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_6844d40ede708325b71da02b604e38f9